### PR TITLE
Add anchor links for subject headings in past papers 🔗

### DIFF
--- a/src/pages/[lang]/past-papers.astro
+++ b/src/pages/[lang]/past-papers.astro
@@ -34,7 +34,7 @@ const grouped = groupPastPaperItems(past_papers);
 								href={`#${medium}-${subject}`}
 								class="no-underline text-inherit"
 							>
-								<h3 id={`${medium}-${subject}`} class="text-2xl">
+								<h3 id={`${medium}-${subject}`} class="text-2xl scroll-mt-20">
 									{formatSubjectName(subject, lang)}
 									<svg
 										xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/[lang]/past-papers.astro
+++ b/src/pages/[lang]/past-papers.astro
@@ -30,7 +30,27 @@ const grouped = groupPastPaperItems(past_papers);
 					<h2 class="text-3xl">{formatMediumName(medium, lang)}</h2>
 					{Object.entries(mediumInfo).map(([subject, groupedSubjects]) => (
 						<>
-							<h3 class="text-2xl">{formatSubjectName(subject, lang)}</h3>
+							<a
+								href={`#${medium}-${subject}`}
+								class="no-underline text-inherit"
+							>
+								<h3 id={`${medium}-${subject}`} class="text-2xl">
+									{formatSubjectName(subject, lang)}
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										width="24"
+										height="24"
+										viewBox="0 0 24 24"
+										fill="currentColor"
+										class="icon icon-tabler icons-tabler-filled icon-tabler-link"
+									>
+										<path stroke="none" d="M0 0h24v24H0z" fill="none" />
+										<path d="M15.707 8.293a1 1 0 0 1 0 1.414l-6 6a1 1 0 1 1 -1.414 -1.414l6 -6a1 1 0 0 1 1.414 0" />
+										<path d="M19.242 4.757c2.343 2.344 2.342 6.143 -.052 8.534l-.534 .464a1 1 0 1 1 -1.312 -1.51l.483 -.416a4 4 0 0 0 0 -5.657c-1.562 -1.563 -4.095 -1.563 -5.607 -.054l-.463 .536a1 1 0 1 1 -1.514 -1.308l.513 -.59a6 6 0 0 1 8.486 .001" />
+										<path d="M6.75 10.338a1 1 0 0 1 -.088 1.411l-.483 .425a3.97 3.97 0 0 0 0 5.649a4.064 4.064 0 0 0 5.678 .038l.34 -.458a1 1 0 1 1 1.606 1.194l-.397 .534l-.1 .114a6.07 6.07 0 0 1 -8.533 0a5.97 5.97 0 0 1 -1.773 -4.247c0 -1.595 .638 -3.124 1.814 -4.284l.524 -.463a1 1 0 0 1 1.411 .087" />
+									</svg>
+								</h3>
+							</a>
 							<div class="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-y-2 gap-x-3">
 								{Object.entries(groupedSubjects).map(([year, paperDetails]) => (
 									<div class="outline outline-gray-200 rounded-lg px-4 py-1 my-1 flex flex-col">


### PR DESCRIPTION


### Improvement

Added anchor links with unique IDs to Pastpaper subjects for better navigation and shareability.

### Benefits

* Easily share direct links to a specific subject
* Improved user experience and accessibility
* Enables URL fragment navigation (`#medium-subject`)


